### PR TITLE
Update the Remove-IntuneUserPfxCertificate command

### DIFF
--- a/src/PFXImportPowershell/README.md
+++ b/src/PFXImportPowershell/README.md
@@ -136,9 +136,11 @@ Get-IntuneUserPfxCertificate
 ```
 
 ## Remove PFX Certificate Example
-1. Remove-PfxCertificates (Specific records)
+1. Remove-PfxCertificate (Specific record)
 ```
-Remove-IntuneUserPfxCertificate -UserThumbprintList <UserThumbprintObjs>
+$Thumbprint_to_delete = "<Certificate_Thumbprint>"  # << Replace it by the desired Certificate Thumbprint
+
+$Certificate_Data = New-Object -TypeName Microsoft.Management.Services.Api.UserPFXCertificate ; $Certificate_Data.Thumbprint = $Thumbprint_to_delete ;$Certificate_Data.UserPrincipalName = (Get-IntuneUserPfxCertificate  | where-object thumbprint -eq $Thumbprint_to_delete).userprincipalname ; Remove-IntuneUserPfxCertificate -CertificateList $Certificate_Data
 ```
 2. Remove-PfxCertificates (Specific users)
 ```


### PR DESCRIPTION
It seems that Remove-IntuneUserPfxCertificate -UserThumbprintList <UserThumbprintObjs> is not working. I noticed that <UserThumbprintObjs> should be of value type "Microsoft.Management.Powershell.PFXImport.Cmdlets.UserThumbprint", so if I pass the thumbprint as a string I will get an error. However, even if I create an object with this type and pass to it the UPN and Thumbprint that I want to delete using the below steps, it doesn't work:

$Test = New-Object -TypeName Microsoft.Management.Powershell.PFXImport.Cmdlets.UserThumbprint

$Test.UserPrincipalName = "<User or UPN>"    # << I tried with both User and UPN
$Test.Thumbprint = "<Thumbprint_to_delete>"

Remove-IntuneUserPfxCertificate -UserThumbprintList  $Test   # << I get no error, but the certificate is not deleted

But I observed that (Get-IntuneUserPfxCertificate -UserThumbprintList  $Test) works and display the certificate.

I noticed that -CertificateList parameter is not documented, but I managed to get it to work with Remove-IntuneUserPfxCertificate -CertificateList using the following 2 lines of code:

$Thumbprint_to_delete = "<Certificate_Thumbprint>"  # << replace it by Certificate thumbprint

$Certificate_Data = New-Object -TypeName Microsoft.Management.Services.Api.UserPFXCertificate ; $Certificate_Data.Thumbprint = $Thumbprint_to_delete ;$Certificate_Data.UserPrincipalName = (Get-IntuneUserPfxCertificate  | where-object thumbprint -eq $Thumbprint_to_delete).userprincipalname ; Remove-IntuneUserPfxCertificate -CertificateList $Certificate_Data